### PR TITLE
Add cross-repo smoke test

### DIFF
--- a/smoke_test/run_smoke_tests.sh
+++ b/smoke_test/run_smoke_tests.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+INPUT_REPO="$ROOT_DIR/aethermind-input"
+PERCEPTION_REPO="$ROOT_DIR/aethermind-perception"
+
+for repo in "$INPUT_REPO" "$PERCEPTION_REPO"; do
+  if [ ! -d "$repo" ]; then
+    echo "Missing repo: $repo" >&2
+    exit 1
+  fi
+  if [ -f "$repo/requirements.txt" ]; then
+    pip install -r "$repo/requirements.txt" || echo "Warning: failed to install dependencies for $repo" >&2
+  fi
+done
+
+SESSION=session_test
+SESSION_DIR="$INPUT_REPO/data/$SESSION"
+rm -rf "$SESSION_DIR"
+mkdir -p "$SESSION_DIR"
+
+mkdir -p "$INPUT_REPO/fixtures"
+echo "dummy" > "$INPUT_REPO/fixtures/test.mp4"
+echo "dummy" > "$INPUT_REPO/fixtures/test.wav"
+cp "$INPUT_REPO/fixtures/test.mp4" "$SESSION_DIR/test.mp4"
+cp "$INPUT_REPO/fixtures/test.wav" "$SESSION_DIR/test.wav"
+echo '{"timestamp":0,"action":"noop"}' > "$SESSION_DIR/actions.jsonl"
+
+OUTPUT_ROOT="$PERCEPTION_REPO/sessions/$SESSION"
+rm -rf "$OUTPUT_ROOT"
+mkdir -p "$OUTPUT_ROOT"
+
+python "$PERCEPTION_REPO/session_runner.py" "$SESSION_DIR" "$OUTPUT_ROOT"
+
+SESSION_JSON="$OUTPUT_ROOT/session.json"
+CLIPS_DIR="$OUTPUT_ROOT/clips"
+
+if [ ! -f "$SESSION_JSON" ]; then
+  echo "FAIL: session.json not found" >&2
+  exit 1
+fi
+
+expected=$(python - "$SESSION_JSON" <<'PY'
+import json,math,sys
+with open(sys.argv[1]) as f:
+    data=json.load(f)
+print(math.ceil(data['clip_length']/data['chunk_duration']))
+PY
+)
+
+actual=$(ls "$CLIPS_DIR" | wc -l)
+
+if [ "$actual" -ne "$expected" ]; then
+  echo "FAIL: expected $expected clips, found $actual" >&2
+  exit 1
+fi
+
+echo "PASS: produced $actual clips"

--- a/smoke_test/test_e2e.py
+++ b/smoke_test/test_e2e.py
@@ -1,0 +1,39 @@
+import json
+import math
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_e2e():
+    root = Path(__file__).resolve().parents[2]
+    input_repo = root / 'aethermind-input'
+    perception_repo = root / 'aethermind-perception'
+
+    assert input_repo.exists(), 'input repo missing'
+    assert perception_repo.exists(), 'perception repo missing'
+
+    session = 'session_test'
+    session_dir = input_repo / 'data' / session
+    if session_dir.exists():
+        shutil.rmtree(session_dir)
+    session_dir.mkdir(parents=True)
+
+    fixture_dir = input_repo / 'fixtures'
+    fixture_dir.mkdir(exist_ok=True)
+    for name in ['test.mp4', 'test.wav']:
+        (fixture_dir / name).write_text('dummy')
+        shutil.copy(fixture_dir / name, session_dir / name)
+    (session_dir / 'actions.jsonl').write_text('{"timestamp":0,"action":"noop"}\n')
+
+    output_root = perception_repo / 'sessions' / session
+    if output_root.exists():
+        shutil.rmtree(output_root)
+
+    subprocess.check_call([sys.executable, str(perception_repo / 'session_runner.py'), str(session_dir), str(output_root)])
+
+    session_json = json.loads((output_root / 'session.json').read_text())
+    expected = math.ceil(session_json['clip_length'] / session_json['chunk_duration'])
+    clips = list((output_root / 'clips').glob('*'))
+    assert len(clips) == expected


### PR DESCRIPTION
## Summary
- add smoke_test script to run perception session runner against mocked fixture data
- add pytest wrapper for e2e smoke test

## Testing
- `smoke_test/run_smoke_tests.sh`
- `pytest smoke_test/test_e2e.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688cc069987c832085fe4bf4ac9761a7